### PR TITLE
HRDetect pivot_wider fix

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,6 @@
 ^README\.Rmd$
 ^\.Rproj\.user$
 ^sigrap\.Rproj$
+^conda$
+^\.github$
+^vignettes$

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+/docs

--- a/R/hrdetect.R
+++ b/R/hrdetect.R
@@ -314,7 +314,6 @@ hrdetect_run <- function(nm, snvindel_vcf, sv_vcf, cnv_tsv, genome = "hg38", snv
   snv <- snvindel$snv_results |>
     dplyr::filter(.data$sig %in% c("Signature.3", "Signature.8")) |>
     tidyr::pivot_wider(
-      id_cols = c("sig", "exposure"),
       names_from = "sig", values_from = "exposure"
     )
 

--- a/vignettes/.gitignore
+++ b/vignettes/.gitignore
@@ -1,0 +1,1 @@
+/outputs

--- a/vignettes/chord.Rmd
+++ b/vignettes/chord.Rmd
@@ -1,13 +1,7 @@
 ---
 title: "CHORD"
-author: "Peter Diakumis"
 date: "`r Sys.Date()`"
-output: rmarkdown::html_vignette
-
-vignette: >
-  %\VignetteIndexEntry{CHORD}
-  %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteEncoding{UTF-8}
+output: rmarkdown::html_document
 ---
 
 ```{r knitr_opts, include = FALSE}

--- a/vignettes/hrdetect.Rmd
+++ b/vignettes/hrdetect.Rmd
@@ -1,13 +1,7 @@
 ---
 title: "HRDetect"
-author: "Peter Diakumis"
 date: "`r Sys.Date()`"
-output: rmarkdown::html_vignette
-
-vignette: >
-  %\VignetteIndexEntry{HRDetect}
-  %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteEncoding{UTF-8}
+output: rmarkdown::html_document
 ---
 
 ```{r knitr_opts, include = FALSE}

--- a/vignettes/mutationalpatterns.Rmd
+++ b/vignettes/mutationalpatterns.Rmd
@@ -1,18 +1,12 @@
 ---
 title: "MutationalPatterns"
-author: "Peter Diakumis"
 date: "`r Sys.time()`"
-output: rmarkdown::html_vignette
+output: rmarkdown::html_document
 resource_files:
   - outputs/sig_plots/Sig
   - outputs/sig_plots/SBS
   - outputs/sig_plots/DBS
   - outputs/sig_plots/ID
-
-vignette: >
-  %\VignetteIndexEntry{MutationalPatterns}
-  %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteEncoding{UTF-8}
 ---
 
 ```{r knitr_opts, include = FALSE}


### PR DESCRIPTION
Fixes (frightening but) small error shown below due to newer v1.2.0 of `{tidyr}` being more vigilant with its col checks in `tidyr::pivot_wider`.

```
Error in `stop_subscript(class = "vctrs_error_subscript_oob", i = i, subscript_type = subscript_type, 
    ...)`: Can't subset columns that don't exist.
x Column `sig` doesn't exist.
Backtrace:
  1. sigrap::hrdetect_run(...)
       at test-roxytest-testexamples-hrdetect.R:77:2
  3. tidyr:::pivot_wider.data.frame(...)
  4. tidyr:::build_wider_id_cols_expr(...)
  5. tidyr:::select_wider_id_cols(...)
  6. tidyselect::eval_select(enquo(id_cols), data)
  7. tidyselect:::eval_select_impl(...)
 16. tidyselect:::vars_select_eval(...)
 17. tidyselect:::walk_data_tree(expr, data_mask, context_mask, error_call)
 18. tidyselect:::eval_c(expr, data_mask, context_mask)
 19. tidyselect:::reduce_sels(node, data_mask, context_mask, init = init)
 20. tidyselect:::walk_data_tree(new, data_mask, context_mask)
 21. tidyselect:::as_indices_sel_impl(...)
 22. tidyselect:::as_indices_impl(x, vars, call = call, strict = strict)
 23. tidyselect:::chr_as_locations(x, vars, call = call)
 24. vctrs::vec_as_location(x, n = length(vars), names = vars)
 25. vctrs `<fn>`()
 26. vctrs:::stop_subscript_oob(...)
 27. vctrs:::stop_subscript(...)
```
